### PR TITLE
@Value 주입 안되는 문제를 해결한다

### DIFF
--- a/src/main/java/myongari/backend/club/infra/ClubImageAwsStorage.java
+++ b/src/main/java/myongari/backend/club/infra/ClubImageAwsStorage.java
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ClubImageAwsStorage implements ClubImageStorage {
 
-    @Value("${spring.cloud.aws.s3.bucket}")
+    @Value("${spring.cloud.aws.s3.bucket:null}")
     private String bucketName;
 
     private final S3Operations s3Operations;


### PR DESCRIPTION
# 이슈
contextLoads() 테스트 실패를 해결한다 issue에 이어지는 해결

Resolves: #7 

# 해결 방법
`@Value` 어노테이션에 default값 `null` 부여

```java
@Value("${spring.cloud.aws.s3.bucket:null}")
    private String bucketName;
```