### PR TITLE
카테고리별 동아리 이름 조회 기능 수정

### DIFF
--- a/src/main/java/myongari/backend/club/infra/ClubJpaRepository.java
+++ b/src/main/java/myongari/backend/club/infra/ClubJpaRepository.java
@@ -19,14 +19,14 @@ public interface ClubJpaRepository extends JpaRepository<Club, Long> {
             + "FROM Club c")
     Page<ClubSimple> findClubSimpleAll(Pageable pageable);
 
-    @Query("SELECT new myongari.backend.club.presentation.dto.ClubName(cl.apply.recruitmentStatus ,cl.name) "
+    @Query("SELECT new myongari.backend.club.presentation.dto.ClubName(cl.id, cl.name, cl.apply.recruitmentStatus ) "
             + "FROM Club cl "
             + "JOIN cl.category c "
             + "WHERE c.name = :categoryName "
             + "ORDER BY CASE "
-            + "WHEN cl.apply.recruitmentStatus = 'Recruiting' THEN 1 "
-            + "WHEN cl.apply.recruitmentStatus = 'Recruited' THEN 2 "
-            + "END, cl.name")
+            + "WHEN cl.apply.recruitmentStatus IN (myongari.backend.club.domain.State.Pending, myongari.backend.club.domain.State.Recruiting) THEN 1 "
+            + "WHEN cl.apply.recruitmentStatus IN (myongari.backend.club.domain.State.Unplanned, myongari.backend.club.domain.State.Recruited, myongari.backend.club.domain.State.ClosedEarly, myongari.backend.club.domain.State.Cancelled) THEN 2 "
+            + "END, cl.name ASC")
     List<ClubName> findClubNamesByCategoryName(@Param("categoryName") String categoryName);
 
     @Query("SELECT c "

--- a/src/main/java/myongari/backend/club/presentation/ClubController.java
+++ b/src/main/java/myongari/backend/club/presentation/ClubController.java
@@ -3,6 +3,7 @@ package myongari.backend.club.presentation;
 import lombok.RequiredArgsConstructor;
 import myongari.backend.club.application.ClubService;
 import myongari.backend.club.domain.Club;
+import myongari.backend.club.presentation.dto.ClubCategory;
 import myongari.backend.club.presentation.dto.ClubName;
 import myongari.backend.club.presentation.dto.ClubSimplePage;
 import myongari.backend.common.response.Success;
@@ -28,11 +29,14 @@ public class ClubController {
                 .body(Success.of(200, clubSimpleAll));
     }
 
-    @GetMapping("/categories/{category_name}/clubs")
-    public ResponseEntity<Success> findClubNamesByCategoryName(@PathVariable(name = "category_name") String categoryName) {
+    @GetMapping("/{category_name}/{club_id}")
+    public ResponseEntity<Success> findClubNamesByCategoryName(@PathVariable(name = "category_name") String categoryName,
+            @PathVariable(name = "club_id") int id) {
         List<ClubName> clubNamesByCategory = clubService.findClubNamesByCategoryName(categoryName);
+        Club club = clubService.findClubById(id);
+        ClubCategory clubCategory = new ClubCategory(clubNamesByCategory, club);
         return ResponseEntity.status(200)
-                .body(Success.of(200, clubNamesByCategory));
+                .body(Success.of(200, clubCategory));
     }
 
     @GetMapping("/clubs/{id}")

--- a/src/main/java/myongari/backend/club/presentation/dto/ClubCategory.java
+++ b/src/main/java/myongari/backend/club/presentation/dto/ClubCategory.java
@@ -1,0 +1,14 @@
+package myongari.backend.club.presentation.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import myongari.backend.club.domain.Club;
+
+@Getter
+@AllArgsConstructor
+public class ClubCategory {
+
+    private List<ClubName> clubNames;
+    private Club club;
+}

--- a/src/main/java/myongari/backend/club/presentation/dto/ClubName.java
+++ b/src/main/java/myongari/backend/club/presentation/dto/ClubName.java
@@ -8,7 +8,7 @@ import myongari.backend.club.domain.State;
 @AllArgsConstructor
 public class ClubName {
 
-    private State recruitmentStatus;
+    private long id;
     private String clubName;
-
+    private State recruitmentStatus;
 }

--- a/src/test/java/myongari/backend/club/fake/ClubFakeRepository.java
+++ b/src/test/java/myongari/backend/club/fake/ClubFakeRepository.java
@@ -36,7 +36,7 @@ public class ClubFakeRepository implements ClubRepository {
     public List<ClubName> findClubNamesByCategoryName(String categoryName) {
         return clubs.stream()
                 .filter(club -> club.getCategory().getName().equals(categoryName))
-                .map(club -> new ClubName(club.getApply().getRecruitmentStatus(), club.getName()))
+                .map(club -> new ClubName(club.getCategory().getId(), club.getName(), club.getApply().getRecruitmentStatus()))
                 .toList();
     }
 


### PR DESCRIPTION
### 이슈
카테고리별 동아리 이름 조회 기능 수정

Resolves:

### 내용
프론트와의 API 설계 과정에서 화면 설계 특성 상 특정 Club 정보를 같이 넘겨주는 것이 맞다고 생각하여,
동아리 클릭 시 카테고리 정보와 동아리 세부 정보를 같이 응답하도록 수정.