### PR TITLE
도메인 URL 분리를 위해 root endpoint를 적용한다

### DIFF
--- a/src/main/java/myongari/backend/club/presentation/ClubController.java
+++ b/src/main/java/myongari/backend/club/presentation/ClubController.java
@@ -12,12 +12,14 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api")
 public class ClubController {
 
     private final ClubService clubService;


### PR DESCRIPTION
# 이슈
root endpoint `/api` 적용

Resolves: #15 

# 내용
Controller 클래스 전역에 `@RequestMapping` 적용